### PR TITLE
(issue28) Fixes NaN being encoded in an unexpected format

### DIFF
--- a/lib/src/value/double.dart
+++ b/lib/src/value/double.dart
@@ -36,9 +36,13 @@ class CborFloat with CborValueMixin implements CborValue {
     sink.addTags(tags);
 
     if (value.isNaN) {
-      // https://datatracker.ietf.org/doc/html/rfc7049#page-27
+      // Any bit pattern can be returned from `toFloat16Bytes()` as long as
+      // it is NaN, so it's a good idea to make sure this is consistent.
       //
-      // If NaN is an allowed value, it must always be represented as 0xf97e00
+      // This value seems to be ideal as it is the value used in canonical
+      // format
+      //
+      // https://datatracker.ietf.org/doc/html/rfc7049#page-27
       sink.add([0xf9, 0x7e, 0x00]);
 
       return;

--- a/lib/src/value/double.dart
+++ b/lib/src/value/double.dart
@@ -35,6 +35,15 @@ class CborFloat with CborValueMixin implements CborValue {
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
+    if (value.isNaN) {
+      // https://datatracker.ietf.org/doc/html/rfc7049#page-27
+      //
+      // If NaN is an allowed value, it must always be represented as 0xf97e00
+      sink.add([0xf9, 0x7e, 0x00]);
+
+      return;
+    }
+
     final parts = FloatParts.fromDouble(value);
 
     if (parts.isFloat16Lossless) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   collection: "^1.15.0"
   typed_data: "^1.3.0"
   convert: "^3.0.0"
-  ieee754: "^1.0.2"
+  ieee754: "^1.0.3"
   meta: "^1.3.0"
 
 dev_dependencies:


### PR DESCRIPTION
As of `ieee754 1.0.3`, NaN is now encoded with one filled mantissa, which is in-spec but made a test fail.

According to the RFC for CBOR the canonical format for NaN should be `0xf97e00`, which was the previous result. The encoder is not following canonical format - it will produce indefinite length lists and maps if it is more efficient -, but a value must be chosen to make the encoder consistent, so this is now being used.
