### PR TITLE
(issue28) Update API to RFC 8949

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [Documentation](https://pub.dev/documentation/cbor/latest/)
 
 This package provides an encoding/decoding package for the Concise Binary Object
-Representation as documented in RFC7049.
+Representation as documented in [RFC8949](https://www.rfc-editor.org/rfc/rfc8949.html).
 
 CBOR is increasingly used as a line protocol in the IOT world where the overhead
 of transmitting JSON on constrained devices can be large in packet size and

--- a/lib/src/codec.dart
+++ b/lib/src/codec.dart
@@ -17,33 +17,12 @@ const CborCodec cbor = CborCodec();
 /// For exceptions [decode] may throw, see [CborDecoder].
 class CborCodec extends Codec<CborValue, List<int>> {
   /// Create a CBOR codec.
-  ///
-  /// If [strict], [decoder] will be in strict mode.
-  ///
-  /// Currently strict mode is on by default, but this may change in the
-  /// future. If you want to rely on this, explicitly add the argument.
-  const CborCodec({bool strict = true}) : _strict = strict;
-
-  final bool _strict;
+  const CborCodec();
 
   @override
-  CborDecoder get decoder {
-    if (_strict) {
-      return const CborDecoder(strict: true);
-    } else {
-      return const CborDecoder(strict: false);
-    }
-  }
-
+  final CborDecoder decoder = const CborDecoder();
   @override
   final CborEncoder encoder = const CborEncoder();
-
-  @override
-  CborValue decode(List<int> input, {bool? strict}) {
-    strict ??= _strict;
-
-    return CborDecoder(strict: strict).convert(input);
-  }
 }
 
 /// Alias for `cbor.encode`.

--- a/lib/src/decoder/pretty_print.dart
+++ b/lib/src/decoder/pretty_print.dart
@@ -70,13 +70,13 @@ class _PrettyPrint extends Sink<RawValue> {
 
     switch (x.header.majorType) {
       case 0:
-        writer.write('(int ${x.header.info.toBigInt()})');
+        writer.write('(int ${x.header.arg.toBigInt()})');
         break;
       case 1:
-        writer.write('(int ${~x.header.info.toBigInt()})');
+        writer.write('(int ${~x.header.arg.toBigInt()})');
         break;
       case 2:
-        final length = x.header.info;
+        final length = x.header.arg;
         if (length.isIndefiniteLength) {
           writer.write('(indefinite length bytes)');
           nested.add(_Nesting(null));
@@ -85,7 +85,7 @@ class _PrettyPrint extends Sink<RawValue> {
         }
         break;
       case 3:
-        final length = x.header.info;
+        final length = x.header.arg;
         if (length.isIndefiniteLength) {
           writer.write('(indefinite length string)');
           nested.add(_Nesting(null));
@@ -95,7 +95,7 @@ class _PrettyPrint extends Sink<RawValue> {
         }
         break;
       case 4:
-        final length = x.header.info;
+        final length = x.header.arg;
         if (length.isIndefiniteLength) {
           writer.write('(indefinite length array)');
           nested.add(_Nesting(null));
@@ -105,7 +105,7 @@ class _PrettyPrint extends Sink<RawValue> {
         }
         break;
       case 5:
-        final length = x.header.info;
+        final length = x.header.arg;
         if (length.isIndefiniteLength) {
           writer.write('(indefinite length map)');
           nested.add(_Nesting(null));
@@ -115,7 +115,7 @@ class _PrettyPrint extends Sink<RawValue> {
         }
         break;
       case 6:
-        writer.write('(tag ${x.header.info.toInt()})');
+        writer.write('(tag ${x.header.arg.toInt()})');
         break;
       case 7:
         switch (x.header.additionalInfo) {
@@ -149,7 +149,7 @@ class _PrettyPrint extends Sink<RawValue> {
             break;
 
           default:
-            writer.write('(simple ${x.header.info.toInt()})');
+            writer.write('(simple ${x.header.arg.toInt()})');
             break;
         }
     }

--- a/lib/src/decoder/stage2.dart
+++ b/lib/src/decoder/stage2.dart
@@ -5,6 +5,8 @@
  * Copyright :  S.Hamblett
  */
 
+import 'package:cbor/cbor.dart';
+
 import 'stage1.dart';
 
 class RawValueTagged {
@@ -30,7 +32,11 @@ class RawSinkTagged extends Sink<RawValue> {
   @override
   void add(RawValue data) {
     if (data.header.majorType == 6) {
-      _tags.add(data.header.info.toInt());
+      if (data.header.arg.isIndefiniteLength) {
+        throw CborMalformedException('Tag can not have additional info 31');
+      }
+
+      _tags.add(data.header.arg.toInt());
     } else {
       sink.add(RawValueTagged(
         data.header,

--- a/lib/src/error.dart
+++ b/lib/src/error.dart
@@ -6,15 +6,13 @@
  */
 
 /// An exception raised when decoding.
-class CborDecodeException implements Exception {
-  const CborDecodeException(this.message, [this.offset]);
-
-  final String message;
-  final int? offset;
+class CborMalformedException extends FormatException {
+  const CborMalformedException(String message, [int? offset])
+      : super(message, offset);
 
   @override
   String toString() {
-    var string = 'CborDecodeException';
+    var string = 'Malformed CBOR';
     if (offset != null) {
       string += ' at $offset';
     }
@@ -24,16 +22,8 @@ class CborDecodeException implements Exception {
   }
 }
 
-/// An exception raised by a [FormatException] when decoding.
-class CborFormatException extends CborDecodeException {
-  CborFormatException(this.formatException, [int? offset])
-      : super('\n$formatException', offset);
-
-  final FormatException formatException;
-}
-
 /// Raised when object could not be codified due to cyclic references.
-class CborCyclicError {
+class CborCyclicError extends Error {
   CborCyclicError(this.cause);
 
   final Object cause;

--- a/lib/src/json.dart
+++ b/lib/src/json.dart
@@ -20,19 +20,28 @@ class CborJsonEncoder extends Converter<CborValue, String> {
   /// as [double.infinity], [double.nan], [CborUndefined].
   const CborJsonEncoder({
     Object? substituteValue,
-  }) : _substituteValue = substituteValue;
+    bool allowMalformedUtf8 = false,
+  })  : _allowMalformedUtf8 = allowMalformedUtf8,
+        _substituteValue = substituteValue;
 
   final Object? _substituteValue;
+  final bool _allowMalformedUtf8;
 
   @override
   String convert(CborValue input) {
-    return json.encode(input.toJson(substituteValue: _substituteValue));
+    return json.encode(input.toJson(
+      substituteValue: _substituteValue,
+      allowMalformedUtf8: _allowMalformedUtf8,
+    ));
   }
 
   @override
   Sink<CborValue> startChunkedConversion(Sink<String> input) {
     return const JsonEncoder()
         .startChunkedConversion(input)
-        .map((x) => x.toJson(substituteValue: _substituteValue));
+        .map((x) => x.toJson(
+              substituteValue: _substituteValue,
+              allowMalformedUtf8: _allowMalformedUtf8,
+            ));
   }
 }

--- a/lib/src/utils/arg.dart
+++ b/lib/src/utils/arg.dart
@@ -5,72 +5,72 @@
  * Copyright :  S.Hamblett
  */
 
-/// The information encoded by additional info and the following bytes.
-abstract class Info {
-  const factory Info.int(int Info) = _InfoInt;
+/// The information encoded by additional Arg and the following bytes.
+abstract class Arg {
+  const factory Arg.int(int arg) = _ArgInt;
 
-  factory Info.bigInt(BigInt Info) = _InfoBigInt;
+  factory Arg.bigInt(BigInt arg) = _ArgBigInt;
 
-  Info operator ~();
+  Arg operator ~();
 
   bool get isIndefiniteLength;
 
   int toInt();
   BigInt toBigInt();
-  int get bitLength;
+  bool get isValidInt;
 
-  static const Info indefiniteLength = _InfoIndefiniteLength();
+  static const Arg indefiniteLength = _ArgIndefiniteLength();
 }
 
-class _InfoIndefiniteLength implements Info {
-  const _InfoIndefiniteLength();
+class _ArgIndefiniteLength implements Arg {
+  const _ArgIndefiniteLength();
 
   @override
-  _InfoIndefiniteLength operator ~() => this;
+  _ArgIndefiniteLength operator ~() => this;
 
   @override
   final bool isIndefiniteLength = true;
 
   @override
-  final int bitLength = 0;
+  final bool isValidInt = false;
   @override
   int toInt() => 0;
   @override
   BigInt toBigInt() => BigInt.zero;
 }
 
-class _InfoInt implements Info {
-  const _InfoInt(this.value);
+class _ArgInt implements Arg {
+  const _ArgInt(this.value);
 
   final int value;
 
   @override
-  _InfoInt operator ~() => _InfoInt(~value);
+  _ArgInt operator ~() => _ArgInt(~value);
 
   @override
   final bool isIndefiniteLength = false;
 
   @override
-  int get bitLength => value.bitLength;
+  final bool isValidInt = true;
   @override
   int toInt() => value;
   @override
   BigInt toBigInt() => BigInt.from(value);
 }
 
-class _InfoBigInt implements Info {
-  _InfoBigInt(this.value);
+class _ArgBigInt implements Arg {
+  _ArgBigInt(this.value);
 
   final BigInt value;
 
   @override
-  _InfoBigInt operator ~() => _InfoBigInt(~value);
+  _ArgBigInt operator ~() => _ArgBigInt(~value);
 
   @override
   final bool isIndefiniteLength = false;
 
   @override
-  int get bitLength => value.bitLength;
+  final bool isValidInt = false;
   @override
   int toInt() => value.toInt();
   @override

--- a/lib/src/value/bytes.dart
+++ b/lib/src/value/bytes.dart
@@ -13,7 +13,7 @@ import 'package:collection/collection.dart';
 import 'package:hex/hex.dart';
 
 import '../encoder/sink.dart';
-import '../utils/info.dart';
+import '../utils/arg.dart';
 import 'internal.dart';
 
 /// A CBOR byte array.
@@ -35,9 +35,11 @@ class _CborBytesImpl with CborValueMixin implements CborBytes {
   String toString() => bytes.toString();
   @override
   bool operator ==(Object other) =>
-      other is CborBytes && bytes.equals(other.bytes);
+      other is CborBytes &&
+      tags.equals(other.tags) &&
+      bytes.equals(other.bytes);
   @override
-  int get hashCode => bytes.hashCode;
+  int get hashCode => Object.hashAll([bytes, tags].flattened);
 
   @override
   Object? toObjectInternal(Set<Object> cyclicCheck, ToObjectOptions o) {
@@ -96,7 +98,7 @@ class _CborEncodeIndefiniteLengthBytesImpl
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(2, Info.indefiniteLength);
+    sink.addHeaderInfo(2, Arg.indefiniteLength);
 
     for (final value in items) {
       CborEncodeDefiniteLengthBytes(CborBytes(value)).encode(sink);
@@ -135,7 +137,7 @@ class _CborEncodeDefiniteLengthBytesImpl
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(2, Info.int(inner.bytes.length));
+    sink.addHeaderInfo(2, Arg.int(inner.bytes.length));
 
     sink.add(inner.bytes);
   }
@@ -214,12 +216,6 @@ class _CborBigIntImpl extends _CborBytesImpl implements CborBigInt {
         cyclicCheck, o.copyWith(encoding: JsonBytesEncoding.base64Url)));
     return output.toString();
   }
-
-  @override
-  bool operator ==(Object other) =>
-      other is CborBigInt &&
-      bytes.equals(other.bytes) &&
-      isNegative == other.isNegative;
 
   @override
   BigInt toBigInt() {

--- a/lib/src/value/double.dart
+++ b/lib/src/value/double.dart
@@ -6,6 +6,7 @@
  */
 
 import 'package:cbor/cbor.dart';
+import 'package:collection/collection.dart';
 import 'package:ieee754/ieee754.dart';
 
 import '../encoder/sink.dart';
@@ -28,9 +29,10 @@ class _CborFloatImpl with CborValueMixin implements CborFloat {
   @override
   String toString() => value.toString();
   @override
-  bool operator ==(Object other) => other is CborFloat && value == other.value;
+  bool operator ==(Object other) =>
+      other is CborFloat && tags.equals(other.tags) && value == other.value;
   @override
-  int get hashCode => value.hashCode;
+  int get hashCode => Object.hash(value, Object.hashAll(tags));
   @override
   final List<int> tags;
 

--- a/lib/src/value/int.dart
+++ b/lib/src/value/int.dart
@@ -8,7 +8,8 @@
 import 'package:cbor/cbor.dart';
 
 import '../encoder/sink.dart';
-import '../utils/info.dart';
+import 'package:collection/collection.dart';
+import '../utils/arg.dart';
 import 'internal.dart';
 
 /// A CBOR integer or big number.
@@ -58,9 +59,11 @@ class _CborSmallIntImpl with CborValueMixin implements CborSmallInt {
   String toString() => value.toString();
   @override
   bool operator ==(Object other) =>
-      other is CborSmallInt && value == other.toInt();
+      other is CborSmallInt &&
+      tags.equals(other.tags) &&
+      value == other.toInt();
   @override
-  int get hashCode => value.hashCode;
+  int get hashCode => Object.hash(value, Object.hashAll(tags));
   @override
   BigInt toBigInt() => BigInt.from(value);
   @override
@@ -87,9 +90,9 @@ class _CborSmallIntImpl with CborValueMixin implements CborSmallInt {
     sink.addTags(tags);
 
     if (!value.isNegative) {
-      sink.addHeaderInfo(0, Info.int(value));
+      sink.addHeaderInfo(0, Arg.int(value));
     } else {
-      sink.addHeaderInfo(1, Info.int(~value));
+      sink.addHeaderInfo(1, Arg.int(~value));
     }
   }
 }
@@ -103,9 +106,11 @@ class _LargeInt with CborValueMixin implements CborInt {
   String toString() => value.toString();
   @override
   bool operator ==(Object other) =>
-      other is CborInt && toBigInt() == other.toBigInt();
+      other is CborInt &&
+      tags.equals(other.tags) &&
+      toBigInt() == other.toBigInt();
   @override
-  int get hashCode => value.hashCode;
+  int get hashCode => Object.hash(value, Object.hashAll(tags));
   @override
   BigInt toBigInt() => value;
   @override
@@ -128,9 +133,9 @@ class _LargeInt with CborValueMixin implements CborInt {
     sink.addTags(tags);
 
     if (!value.isNegative) {
-      sink.addHeaderInfo(0, Info.bigInt(value));
+      sink.addHeaderInfo(0, Arg.bigInt(value));
     } else {
-      sink.addHeaderInfo(1, Info.bigInt(~value));
+      sink.addHeaderInfo(1, Arg.bigInt(~value));
     }
   }
 }

--- a/lib/src/value/internal.dart
+++ b/lib/src/value/internal.dart
@@ -11,24 +11,27 @@ import 'package:cbor/cbor.dart';
 import 'package:meta/meta.dart';
 
 import '../encoder/sink.dart';
-import '../utils/info.dart';
+import '../utils/arg.dart';
 
 class ToObjectOptions {
   ToObjectOptions({
     required this.parseDateTime,
     required this.parseUri,
     required this.decodeBase64,
+    required this.allowMalformedUtf8,
   });
 
   final bool parseDateTime;
   final bool parseUri;
   final bool decodeBase64;
+  final bool allowMalformedUtf8;
 }
 
 class ToJsonOptions {
   ToJsonOptions({
     required this.encoding,
     this.substituteValue,
+    required this.allowMalformedUtf8,
   });
 
   ToJsonOptions copyWith({
@@ -37,9 +40,11 @@ class ToJsonOptions {
       ToJsonOptions(
         encoding: encoding ?? this.encoding,
         substituteValue: substituteValue,
+        allowMalformedUtf8: allowMalformedUtf8,
       );
 
   final JsonBytesEncoding encoding;
+  final bool allowMalformedUtf8;
   final Object? substituteValue;
 }
 
@@ -70,7 +75,7 @@ class Break with CborValueMixin implements CborValue {
 
   @override
   void encode(EncodeSink sink) {
-    sink.addHeaderInfo(7, Info.indefiniteLength);
+    sink.addHeaderInfo(7, Arg.indefiniteLength);
   }
 }
 
@@ -81,6 +86,7 @@ mixin CborValueMixin implements CborValue {
     bool parseDateTime = true,
     bool parseUri = true,
     bool decodeBase64 = false,
+    bool allowMalformedUtf8 = false,
   }) =>
       toObjectInternal(
           {},
@@ -88,13 +94,16 @@ mixin CborValueMixin implements CborValue {
             parseDateTime: parseDateTime,
             parseUri: parseUri,
             decodeBase64: decodeBase64,
+            allowMalformedUtf8: allowMalformedUtf8,
           ));
 
   @override
-  Object? toJson({Object? substituteValue}) => toJsonInternal(
+  Object? toJson({Object? substituteValue, bool allowMalformedUtf8 = false}) =>
+      toJsonInternal(
         {},
         ToJsonOptions(
           encoding: JsonBytesEncoding.base64Url,
+          allowMalformedUtf8: allowMalformedUtf8,
           substituteValue: substituteValue,
         ),
       );

--- a/lib/src/value/list.dart
+++ b/lib/src/value/list.dart
@@ -9,7 +9,7 @@ import 'package:cbor/cbor.dart';
 import 'package:collection/collection.dart';
 
 import '../encoder/sink.dart';
-import '../utils/info.dart';
+import '../utils/arg.dart';
 import 'internal.dart';
 
 /// A CBOR array.
@@ -118,7 +118,7 @@ class _CborEncodeIndefiniteLengthListImpl
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(4, Info.indefiniteLength);
+    sink.addHeaderInfo(4, Arg.indefiniteLength);
 
     sink.addToCycleCheck(inner);
     for (final x in inner) {
@@ -163,7 +163,7 @@ class _CborEncodeDefiniteLengthListImpl
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(4, Info.int(inner.length));
+    sink.addHeaderInfo(4, Arg.int(inner.length));
 
     sink.addToCycleCheck(inner);
     for (final x in inner) {
@@ -222,7 +222,7 @@ class _CborDecimalFractionImpl extends DelegatingList<CborValue>
   @override
   void encode(EncodeSink sink) {
     sink.addTags(tags);
-    sink.addHeaderInfo(4, Info.int(2));
+    sink.addHeaderInfo(4, Arg.int(2));
     exponent.encode(sink);
     mantissa.encode(sink);
   }
@@ -265,7 +265,7 @@ class _CborBigFloatImpl extends DelegatingList<CborValue>
   @override
   void encode(EncodeSink sink) {
     sink.addTags(tags);
-    sink.addHeaderInfo(4, Info.int(2));
+    sink.addHeaderInfo(4, Arg.int(2));
     exponent.encode(sink);
     mantissa.encode(sink);
   }

--- a/lib/src/value/map.dart
+++ b/lib/src/value/map.dart
@@ -11,7 +11,7 @@ import 'package:cbor/cbor.dart';
 import 'package:collection/collection.dart';
 
 import '../encoder/sink.dart';
-import '../utils/info.dart';
+import '../utils/arg.dart';
 import 'internal.dart';
 
 /// A CBOR map.
@@ -130,7 +130,7 @@ class _CborEncodeIndefiniteLengthMapImpl
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(5, Info.indefiniteLength);
+    sink.addHeaderInfo(5, Arg.indefiniteLength);
 
     sink.addToCycleCheck(inner);
     for (final e in inner.entries) {
@@ -175,7 +175,7 @@ class _CborEncodeDefiniteLengthMapImpl
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(5, Info.int(inner.length));
+    sink.addHeaderInfo(5, Arg.int(inner.length));
 
     sink.addToCycleCheck(inner);
     for (final e in inner.entries) {

--- a/lib/src/value/simple_value.dart
+++ b/lib/src/value/simple_value.dart
@@ -6,13 +6,15 @@
  */
 
 import 'package:cbor/cbor.dart';
+import 'package:collection/collection.dart';
 
 import '../encoder/sink.dart';
-import '../utils/info.dart';
+import '../utils/arg.dart';
 import 'internal.dart';
 
 /// A CBOR simple value without any
 /// additional content.
+
 abstract class CborSimpleValue extends CborValue {
   const factory CborSimpleValue(int simpleValue, {List<int> tags}) =
       _CborSimpleValueImpl;
@@ -30,9 +32,11 @@ class _CborSimpleValueImpl with CborValueMixin implements CborSimpleValue {
   String toString() => simpleValue.toString();
   @override
   bool operator ==(Object other) =>
-      other is CborSimpleValue && other.simpleValue == simpleValue;
+      other is CborSimpleValue &&
+      tags.equals(other.tags) &&
+      other.simpleValue == simpleValue;
   @override
-  int get hashCode => simpleValue.hashCode;
+  int get hashCode => Object.hash(simpleValue, Object.hashAll(tags));
   @override
   final List<int> tags;
 
@@ -45,7 +49,7 @@ class _CborSimpleValueImpl with CborValueMixin implements CborSimpleValue {
   void encode(EncodeSink sink) {
     sink.addTags(tags);
 
-    sink.addHeaderInfo(7, Info.int(simpleValue));
+    sink.addHeaderInfo(7, Arg.int(simpleValue));
   }
 
   @override

--- a/lib/src/value/value.dart
+++ b/lib/src/value/value.dart
@@ -220,6 +220,7 @@ abstract class CborValue {
     bool parseDateTime = true,
     bool parseUri = true,
     bool decodeBase64 = false,
+    bool allowMalformedUtf8 = false,
   });
 
   /// Transform this into a JSON encodable value.
@@ -231,6 +232,7 @@ abstract class CborValue {
   /// as JSON, and the string is used.
   Object? toJson({
     Object? substituteValue,
+    bool allowMalformedUtf8 = false,
   });
 
   /// <nodoc>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: cbor
-description: A CBOR library for Dart. An RFC7049 compliant encoding/decoding CBOR implementation.
+description: A CBOR library for Dart. An RFC8949 compliant encoding/decoding CBOR implementation.
 version: 4.1.0
 homepage: https://github.com/shamblett/cbor
 

--- a/test/decoder_rfc_test.dart
+++ b/test/decoder_rfc_test.dart
@@ -302,15 +302,19 @@ void main() {
 
     test('Tag (23) multiple', () {
       final decoded = cbor.decode([0xd7, 0x44, 0x01, 0x02, 0x03, 0x04]);
-      expect(decoded, CborBytes([1, 2, 3, 4]));
-      expect(decoded.tags, [CborTag.expectedConversionToBase16]);
+      expect(
+          decoded,
+          CborBytes(
+            [1, 2, 3, 4],
+            tags: [CborTag.expectedConversionToBase16],
+          ));
     });
 
     test('Tag (24) multiple', () {
       final decoded =
           cbor.decode([0xd8, 0x18, 0x45, 0x64, 0x49, 0x45, 0x54, 0x46]);
-      expect(decoded, CborBytes([100, 73, 69, 84, 70]));
-      expect(decoded.tags, [CborTag.encodedCborData]);
+      expect(decoded,
+          CborBytes([100, 73, 69, 84, 70], tags: [CborTag.encodedCborData]));
     });
 
     test('Tag (32) URI', () {

--- a/test/supplementary_test.dart
+++ b/test/supplementary_test.dart
@@ -219,19 +219,17 @@ void main() {
   });
 
   group('Error handling', () {
-    const strictCbor = CborCodec(strict: true);
-
     test('No input', () {
-      expect(() => strictCbor.decode([]), throwsException);
+      expect(() => cbor.decode([]), throwsException);
     });
 
     test('Random bytes', () {
-      expect(() => strictCbor.decode([0xcd, 0xfe, 0x00]), throwsException);
+      expect(() => cbor.decode([0xcd, 0xfe, 0x00]), throwsException);
     });
 
     test('Premature termination', () {
       expect(
-        () => strictCbor.decode([0x44, 0x01, 0x02, 0x03]),
+        () => cbor.decode([0x44, 0x01, 0x02, 0x03]),
         throwsException,
       );
     });


### PR DESCRIPTION
This updates the API to [RFC8949](https://www.rfc-editor.org/rfc/rfc8949.html).

In particular, strict mode has been removed. Now the decoder will throw if not well-formed inputs are found, and invalid inputs are accepted but will throw when parsed by the user.

One exception is that the decoder will not throw if the concatenation of a indefinite length string is valid but the individual strings are not. This is out of spec, but should not cause any problems as it will just accept some not well-formed inputs.

The equality implementation now properly verifies all tags.

Also the internal "Info" has been renamed to "Arg", as it is called argument in the RFC.