### PR TITLE
Fixes wrong decoding of integers

### DIFF
--- a/lib/src/decoder/stage0.dart
+++ b/lib/src/decoder/stage0.dart
@@ -33,29 +33,6 @@ class Reader {
     return readExactBytes(1)?[0];
   }
 
-  int? readUint16(int offset) {
-    final bytes = readExactBytes(2);
-    if (bytes != null) {
-      return ByteData.view(bytes.buffer).getUint16(0);
-    }
-  }
-
-  int? readUint32(int offset) {
-    final bytes = readExactBytes(4);
-    if (bytes != null) {
-      return ByteData.view(bytes.buffer).getUint32(0);
-    }
-  }
-
-  BigInt? readUint64(int offset) {
-    final bytes = readExactBytes(4);
-    if (bytes != null) {
-      var i = BigInt.from(ByteData.view(bytes.buffer).getUint32(0)) << 4;
-      i |= BigInt.from(ByteData.view(bytes.buffer).getUint32(4));
-      return i;
-    }
-  }
-
   Uint8List? readExactBytes(int c) {
     if (_read + c <= _bytes.length) {
       final bytes = _bytes.buffer.asUint8List().sublist(_read, c + _read);

--- a/lib/src/decoder/stage1.dart
+++ b/lib/src/decoder/stage1.dart
@@ -30,9 +30,9 @@ class Header {
         case 24:
           return Arg.int(dataBytes[0]);
         case 25:
-          return Arg.int(ByteData.view(dataBytes.buffer).getInt16(0));
+          return Arg.int(ByteData.view(dataBytes.buffer).getUint16(0));
         case 26:
-          return Arg.int(ByteData.view(dataBytes.buffer).getInt32(0));
+          return Arg.int(ByteData.view(dataBytes.buffer).getUint32(0));
         case 27:
           var i =
               BigInt.from(ByteData.view(dataBytes.buffer).getUint32(0)) << 32;

--- a/test/issues/issue41_test.dart
+++ b/test/issues/issue41_test.dart
@@ -1,0 +1,17 @@
+/*
+ * Package : Cbor
+ * Author : S. Hamblett <steve.hamblett@linux.com>
+ * Date   : 02/04/2020
+ * Copyright :  S.Hamblett
+ */
+import 'package:convert/convert.dart';
+import 'package:cbor/cbor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('63254', () {
+    final decoded = cbor.decode([25, 247, 22]);
+
+    expect(decoded, CborSmallInt(63254));
+  });
+}


### PR DESCRIPTION
Integers of size 16 and 32 where being decoding in 2 complement, which caused some unsigned values to be decoded as negative, as reported in #41.

I added a test case as well.