### PR TITLE
Update Bitwise Complement Operator and Type Checks for Web Compatibility

### DIFF
--- a/lib/src/utils/arg.dart
+++ b/lib/src/utils/arg.dart
@@ -5,6 +5,8 @@
  * Copyright :  S.Hamblett
  */
 
+import 'utils.dart';
+
 /// The information encoded by additional Arg and the following bytes.
 abstract class Arg {
   const factory Arg.int(int arg) = _ArgInt;
@@ -45,7 +47,7 @@ class _ArgInt implements Arg {
   final int value;
 
   @override
-  _ArgInt operator ~() => _ArgInt(~value);
+  _ArgInt operator ~() => _ArgInt(kIsWeb ? -value - 1 : ~value);
 
   @override
   final bool isIndefiniteLength = false;

--- a/lib/src/utils/arg.dart
+++ b/lib/src/utils/arg.dart
@@ -5,8 +5,6 @@
  * Copyright :  S.Hamblett
  */
 
-import 'utils.dart';
-
 /// The information encoded by additional Arg and the following bytes.
 abstract class Arg {
   const factory Arg.int(int arg) = _ArgInt;
@@ -47,7 +45,7 @@ class _ArgInt implements Arg {
   final int value;
 
   @override
-  _ArgInt operator ~() => _ArgInt(kIsWeb ? -value - 1 : ~value);
+  _ArgInt operator ~() => _ArgInt((~value).toSigned(32));
 
   @override
   final bool isIndefiniteLength = false;

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -137,3 +137,9 @@ bool isExpectConversion(int tag) {
 
   return false;
 }
+
+const bool kIsWeb = identical(0, 0.0);
+
+bool isWebDouble(Object a) {
+  return (a as double).toInt() == a;
+}

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -137,9 +137,3 @@ bool isExpectConversion(int tag) {
 
   return false;
 }
-
-const bool kIsWeb = identical(0, 0.0);
-
-bool isWebDouble(Object a) {
-  return a is double && a.toInt() == a;
-}

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -141,5 +141,5 @@ bool isExpectConversion(int tag) {
 const bool kIsWeb = identical(0, 0.0);
 
 bool isWebDouble(Object a) {
-  return (a as double).toInt() == a;
+  return a is double && a.toInt() == a;
 }

--- a/lib/src/value/value.dart
+++ b/lib/src/value/value.dart
@@ -62,8 +62,8 @@ abstract class CborValue {
       return CborNull();
     } else if (object is CborValue) {
       return object;
-    } else if (!kIsWeb && object is double || kIsWeb && isWebDouble(object)) {
-      return CborFloat(object as double);
+    } else if (object is double && (!kIsWeb || kIsWeb && isWebDouble(object))) {
+      return CborFloat(object);
     } else if (object is int) {
       return CborSmallInt(object);
     } else if (object is BigInt) {

--- a/lib/src/value/value.dart
+++ b/lib/src/value/value.dart
@@ -8,6 +8,7 @@
 import 'dart:typed_data';
 
 import 'package:cbor/cbor.dart';
+import 'package:cbor/src/utils/utils.dart';
 import 'package:meta/meta.dart';
 
 import '../encoder/sink.dart';
@@ -61,8 +62,8 @@ abstract class CborValue {
       return CborNull();
     } else if (object is CborValue) {
       return object;
-    } else if (object is double) {
-      return CborFloat(object);
+    } else if (!kIsWeb && object is double || kIsWeb && isWebDouble(object)) {
+      return CborFloat(object as double);
     } else if (object is int) {
       return CborSmallInt(object);
     } else if (object is BigInt) {

--- a/lib/src/value/value.dart
+++ b/lib/src/value/value.dart
@@ -8,7 +8,6 @@
 import 'dart:typed_data';
 
 import 'package:cbor/cbor.dart';
-import 'package:cbor/src/utils/utils.dart';
 import 'package:meta/meta.dart';
 
 import '../encoder/sink.dart';
@@ -62,12 +61,12 @@ abstract class CborValue {
       return CborNull();
     } else if (object is CborValue) {
       return object;
-    } else if (object is double && (!kIsWeb || kIsWeb && isWebDouble(object))) {
-      return CborFloat(object);
     } else if (object is int) {
       return CborSmallInt(object);
     } else if (object is BigInt) {
       return CborInt(object);
+    } else if (object is double) {
+      return CborFloat(object);
     } else if (object is bool) {
       return CborBool(object);
     } else if (object is Uint8List) {


### PR DESCRIPTION
This pull request introduces changes to the handling of the bitwise complement operator and type checks to accommodate differences in behavior between native and web environments. The changes are detailed below:

1. **Modification of Bitwise Complement (~) Operation:**
   - In web environments, the behavior of `~4` is not equivalent to `-5` as it is in native environments. To address this discrepancy, the implementation of the `~` operator in `_ArgInt` has been updated. 
   - Now, it checks if the code is running on the web (using `kIsWeb`) and, if so, applies `-value - 1` instead of the native `~value`. This change ensures consistent results across platforms.

2. **Type Checking for Integer Objects:**
   - Due to the dual nature of integers on the web, where they can be represented as both `int` and `double`, the existing type check was inadequate. 
   - A new utility function `isWebDouble` has been introduced to accurately determine if an object is a double type representing an integer on the web.
   - Consequently, the condition for encoding an object as `CborFloat` in `CborValue` has been updated to include a check using `isWebDouble`, ensuring correct type interpretation on the web.

3. **Implications for Encoding Float-like Integers and Unaffected Native Behavior:**
   - Post this update, encoding a float-like integer on the web requires manual handling. This change is necessary to align with the modified type-checking logic and maintain accuracy in data representation.
   - It's important to note that these changes do not impact the native code, ensuring that existing functionality remains consistent for native applications.

#### Affected Files:
- `lib/src/utils/arg.dart`
- `lib/src/utils/utils.dart`
- `lib/src/value/value.dart`
