### PR TITLE
Fixed negative small int CBOR de-serializing

### DIFF
--- a/lib/src/utils/arg.dart
+++ b/lib/src/utils/arg.dart
@@ -45,7 +45,7 @@ class _ArgInt implements Arg {
   final int value;
 
   @override
-  _ArgInt operator ~() => _ArgInt((~value).toSigned(32));
+  _ArgInt operator ~() => _ArgInt((~value).toSigned(33));
 
   @override
   final bool isIndefiniteLength = false;

--- a/test/int_test.dart
+++ b/test/int_test.dart
@@ -1,0 +1,52 @@
+/*
+ * Package : Cbor
+ * Author : Alex Dochioiu <alex@vespr.xyz>
+ * Date   : 19/06/2024
+ * Copyright :  Alex Dochioiu
+ */
+
+import 'package:cbor/cbor.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group("Int Numbers Test", () {
+    final numbersToTest = [
+      BigInt.parse("0"),
+      BigInt.parse("1"),
+      BigInt.parse("2656159029"),
+      BigInt.parse("4294967295"),
+      BigInt.parse("4294967296"),
+      BigInt.parse("4294967299"),
+      BigInt.parse("5294967590"),
+      BigInt.parse("91234567890"),
+      BigInt.parse("912345678901234567890"),
+    ];
+
+    group("positive numbers", () {
+      for (final number in numbersToTest) {
+        test(number.toString(), () {
+          final cborInt = CborInt(number);
+          final serialized = cborEncode(cborInt);
+          final deserialized = cborDecode(serialized);
+          expect(cborInt.toBigInt(), number);
+          expect(deserialized, isA<CborInt>());
+          expect((deserialized as CborInt).toBigInt(), number);
+        });
+      }
+    });
+
+    group("negative numbers", () {
+      for (final positiveNumber in numbersToTest) {
+        final number = BigInt.zero - positiveNumber;
+        test(number.toString(), () {
+          final cborInt = CborInt(number);
+          final serialized = cborEncode(cborInt);
+          final deserialized = cborDecode(serialized);
+          expect(cborInt.toBigInt(), number);
+          expect(deserialized, isA<CborInt>());
+          expect((deserialized as CborInt).toBigInt(), number);
+        });
+      }
+    });
+  });
+}


### PR DESCRIPTION
There is a bug where negative 33-bit ints (sign bit + 32-bit number) are serialized correctly but when reading the number, the value is truncated to 32-bits **including the sign bit**. 

This effectively removes truncates one bit out of all 33-bit negative numbers (33-bit including sign bit)

P.s. you can run the added tests without the change and you'll see a few failing.