### PR TITLE
Fixed negate and toSigned operation in JS

### DIFF
--- a/lib/src/utils/arg.dart
+++ b/lib/src/utils/arg.dart
@@ -45,7 +45,7 @@ class _ArgInt implements Arg {
   final int value;
 
   @override
-  _ArgInt operator ~() => _ArgInt((~value).toSigned(33));
+  _ArgInt operator ~() => _ArgInt((~BigInt.from(value)).toSigned(33).toInt());
 
   @override
   final bool isIndefiniteLength = false;

--- a/lib/src/value/int.dart
+++ b/lib/src/value/int.dart
@@ -92,7 +92,7 @@ class _CborSmallIntImpl with CborValueMixin implements CborSmallInt {
     if (!value.isNegative) {
       sink.addHeaderInfo(0, Arg.int(value));
     } else {
-      sink.addHeaderInfo(1, Arg.int(~value));
+      sink.addHeaderInfo(1, Arg.int((~BigInt.from(value)).toInt()));
     }
   }
 }


### PR DESCRIPTION
I spent probably 6 hours trying to find the root cause of some issue, which seems to be routed in how `~` and `toSigned` works (or doesn't) when library is compiled to JS.

put this code in `lib/main.js` (or wherever)
```dart
import 'package:cbor/cbor.dart';
import 'package:hex/hex.dart';

void main() {
  final numbersToTestNegative = [
    BigInt.parse("-0"),
    BigInt.parse("-1"),
    BigInt.parse("-2656159029"),
    BigInt.parse("-4294967295"),
    BigInt.parse("-4294967296"),
    BigInt.parse("-4294967299"),
    BigInt.parse("-5294967590"),
    BigInt.parse("-91234567890"),
    BigInt.parse("-912345678901234567890"),
  ];
  for (final number in numbersToTestNegative) {
    final cborInt = CborInt(number);
    final serialized = cborEncode(cborInt);

    final deserialized = cborDecode(serialized);
    print(number.toString() == (deserialized as CborInt).toBigInt().toString());
  }
}
```

And run
```sh
dart compile js lib/main.dart -o lib/main.dart.js -O1 
node lib/main.dart.js
```