### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,104 +1,107 @@
 ### 6.3.6
-Issue 72
+- [Issue 72](https://github.com/shamblett/cbor/issues/72)
 
 ### 6.3.5
-Issue 68
+- [Issue 68](https://github.com/shamblett/cbor/issues/68)
 
 ### 6.3.4
-Issue 66
+- [Issue 66](https://github.com/shamblett/cbor/issues/66)
 
 ### 6.3.3
-PR 65
+- [PR 65](https://github.com/shamblett/cbor/pull/65)
 
 ### 6.3.2
-PR 64
+- [PR 64](https://github.com/shamblett/cbor/pull/64)
 
 ### 6.3.1
-Issue 62
+- [Issue 62](https://github.com/shamblett/cbor/issues/62)
 
 ### 6.3.0
-PR60
+- [PR 60](https://github.com/shamblett/cbor/pull/60)
 
 ### 6.2.0
-PR58
+- [PR 58](https://github.com/shamblett/cbor/pull/58)
 
 ### 6.1.1
-Issue 56, PR57
+- [Issue 56](https://github.com/shamblett/cbor/issues/56)
+- [PR 57](https://github.com/shamblett/cbor/pull/57)
 
 ### 6.1.0
-Issue 51, PR52
+- [Issue 51](https://github.com/shamblett/cbor/issues/51)
+- [PR 52](https://github.com/shamblett/cbor/pull/52)
 
 ### 6.0.0
-Issue 54 - Dart 3
+- [Issue 54](https://github.com/shamblett/cbor/issues/54) - Dart 3
 
 ### 5.1.2
-Issue 48
+- [Issue 48](https://github.com/shamblett/cbor/issues/48)
 
 ### 5.1.1
-Issue 46
+- [Issue 46](https://github.com/shamblett/cbor/issues/46)
 
 ### 5.1.0
-Issue 44
+- [Issue 44](https://github.com/shamblett/cbor/issues/44)
 
 ### 5.0.1
-Issue 41, PR42
+- [Issue 41](https://github.com/shamblett/cbor/issues/41)
+- [PR 42](https://github.com/shamblett/cbor/pull/42)
 
 ### 5.0.0
-Issue 28 - API rewrite - 
+
 ***Warning - major breaking API change in this version***
 
+- [Issue 28](https://github.com/shamblett/cbor/issues/28) - API rewrite
+
 ### 4.1.0
-Issue 2 - Byte string keys added
+- [Issue 2](https://github.com/shamblett/cbor/issues/2) - Byte string keys added
 
 ### 4.0.2
-Issue 5
+- [Issue 5](https://github.com/shamblett/cbor/issues/5)
 
 ### 4.0.1
-Issue 21
+- [Issue 21](https://github.com/shamblett/cbor/issues/21)
 
 ### 4.0.0
-Issues 18 and 14(NNBD)
+- [Issues 18 and 14 (NNBD)](https://github.com/shamblett/cbor/issues/18)
+- [Issues 14 (NNBD)](https://github.com/shamblett/cbor/issues/14)
 
 ### 3.2.0
-Issue 13
+- [Issue 13](https://github.com/shamblett/cbor/issues/13)
 
 ### 3.1.0
-Issue 5
+- [Issue 5](https://github.com/shamblett/cbor/issues/5)
 
 ### 3.0.0
-Issue 10
+- [Issue 10](https://github.com/shamblett/cbor/issues/10)
 
 ### 2.1.0
-Issue 9
+- [Issue 9](https://github.com/shamblett/cbor/issues/9)
 
 ### 2.0.5
-Linter rules update
+- Linter rules update
 
 ### 2.0.4
-Linter rules update
+- Linter rules update
 
 ### 2.0.3
-Issue 6, linter rules update
+- [Issue 6](https://github.com/shamblett/cbor/issues/6)
+- Linter rules update
 
 ### 2.0.2
-
-Issue 4, update to Dart 2
+- [Issue 4](https://github.com/shamblett/cbor/issues/4), update to Dart 2
 
 ### 1.0.4
-Updates for pub. Remove json_mapper
+- Updates for pub. Remove json_mapper
 
 ### 1.0.3
-Strong mode updates for pub.
+- Strong mode updates for pub.
 
 ### 1.0.2
-
 - SDK version constraint update
 
 ### 1.0.1
-
-- Minor update to the README, issue 1.
+- Minor update to the README,
+  [issue 1](https://github.com/shamblett/cbor/issues/1).
 
 ## 1.0.0
-
 - Initial version
-


### PR DESCRIPTION
When I visited the package at the pub.dev, I wanted to know what had changed with its new version. To do that with the current CHAGNELOG, I need to remember the number and open the corresponding link with the repo to know the details.

This is the first batch of changes to improve the readability of the changelog. A following PR might extract the changes description from those links.